### PR TITLE
Docker build steps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
+**/node_modules
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:12
+
+ENV npm_config_cache /usr/npmcache
+WORKDIR /usr/src/flit
+
+# copy package definitions for install
+COPY package*.json ./
+COPY flit-client/package*.json flit-client/
+COPY flit-server/package*.json flit-server/
+
+RUN npm install
+RUN npm install flit-client
+RUN npm install flit-server
+
+# copy the source after dependencies are installed
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,22 @@ ENV npm_config_cache /usr/npmcache
 WORKDIR /usr/src/flit
 
 # copy package definitions for install
-COPY package*.json ./
+# COPY package*.json ./
 COPY flit-client/package*.json flit-client/
 COPY flit-server/package*.json flit-server/
 
+WORKDIR /usr/src/flit/flit-client
 RUN npm install
-RUN npm install flit-client
-RUN npm install flit-server
+WORKDIR /usr/src/flit/flit-server
+RUN npm install
+
 
 # copy the source after dependencies are installed
+WORKDIR /usr/src/flit
 COPY . .
+
+# Run the build scripts
+WORKDIR /usr/src/flit/flit-client
+RUN npm run build
+WORKDIR /usr/src/flit/flit-server
+RUN npm run build

--- a/README.md
+++ b/README.md
@@ -2,8 +2,55 @@
 
 This is a quick-and-dirty monorepo for development purposes, containing two separate repos.
 
-`flit-client` contains the frontend client, which was bootstrapped with `create-react-app` using the
-TypeScript template. The command used was `npx create-react-app flit-client --template typescript`.
+* `flit-client` contains the frontend client.
+* `flit-server` contains the backend service.
+
+== Running
+
+To run the client, from a command prompt in the `flit-client` folder, run:
+```
+ npm install
+ npm run build
+ npm start
+```
+
+To run the server, from a command prompt in the `flit-server` folder, run:
+```
+ npm install
+ npm run build
+ npm start
+```
+
+By default the client starts a service on port 3000, and the server on
+port 4000.
+
+=== Docker
+
+To run in docker, from the `flit` project directory, run:
+
+`docker compose up -d`
+
+This will build an image with node depenencies and start a container
+named `flit_dev_1`.
+
+To start the client and server, connect to the container by running:
+
+`docker exec -ti dev_flit_1 bash`
+
+then, within the container, start the client with:
+```
+cd /usr/src/flit/flit-client
+npm start
+```
+
+or the server with:
+```
+cd /usr/src/flit/flit-server
+npm start
+```
+
+=== History
+`flit-client` was bootstrapped with `create-react-app` using the TypeScript template. The command used was `npx create-react-app flit-client --template typescript`.
 
 `flit-server` contains the backend service, which was bootstrapped from the [Microsoft *TypeScript
 Node Starter* repo](https://github.com/microsoft/TypeScript-Node-Starter). The command used was 
@@ -14,3 +61,4 @@ security vulnerabilities.
 The git repos created by both these bootstrap steps were then destroyed by calling `rm -rf .git`
 within the `flit-client` and `flit-server` directories, a new git repo was set up in the root
 directory with `git init`, and the initial state of both directories was committed to it.
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+cd ./flit-client
+npm install
+npm run build
+cd ../flit-server
+npm install
+npm run build
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     build:
       context: .
     image: flit
+    init: true
     ports:
       - "3000:3000"
     # start a shell with tty, so the container stays up.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.7"
+# Setup for a dev host.
+# usage: `docker-compose up -d`
+
+services:
+  dev:
+    build:
+      context: .
+    image: flit
+    ports:
+      - "3000:3000"
+    # start a shell with tty, so the container stays up.
+    # connect with `docker exec -ti flit_dev_1 bash`
+    command: [ "bash" ]
+    tty: true
+    volumes:
+      - ".:/usr/src/live"


### PR DESCRIPTION
Tested:
* `docker build .`
* `docker-compose build`

Then within the container ( `docker exec -ti flit_dev_1 bash` ), running `npm start` from the flit-client directory.