### PR TITLE
run npm audit fix

### DIFF
--- a/flit-server/package-lock.json
+++ b/flit-server/package-lock.json
@@ -4329,8 +4329,7 @@
                 },
                 "kind-of": {
                     "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "resolved": "",
                     "dev": true
                 }
             }
@@ -5493,9 +5492,9 @@
                     }
                 },
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
                     "dev": true
                 }
             }
@@ -5963,9 +5962,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-                    "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+                    "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
                     "dev": true
                 }
             }
@@ -6344,8 +6343,7 @@
                 },
                 "kind-of": {
                     "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "resolved": "",
                     "dev": true
                 }
             }
@@ -11471,9 +11469,9 @@
             },
             "dependencies": {
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
                     "dev": true
                 }
             }
@@ -11512,9 +11510,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minipass": {
             "version": "2.9.0",
@@ -11562,18 +11560,11 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "requires": {
-                "minimist": "0.0.8"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
+                "minimist": "^1.2.5"
             }
         },
         "moment": {
@@ -11625,9 +11616,9 @@
             },
             "dependencies": {
                 "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
                     "dev": true
                 }
             }
@@ -14056,8 +14047,7 @@
                 },
                 "kind-of": {
                     "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "resolved": "",
                     "dev": true
                 }
             }


### PR DESCRIPTION
`npm audit` reported issues; this resolves many of them

(additional low-severity issues in Jest are still reported; `npm audit fix` claims to fix them, but no files in the repo are changed and the issues are still reported by a subsequent run of `npm audit`. They're deep enough in test code that they're implausible as an exploitable vulnerability.