### PR TITLE
update apollo-link

### DIFF
--- a/flit-server/package-lock.json
+++ b/flit-server/package-lock.json
@@ -3938,14 +3938,14 @@
             }
         },
         "apollo-link": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
-            "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
+            "version": "1.2.14",
+            "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+            "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
             "requires": {
                 "apollo-utilities": "^1.3.0",
                 "ts-invariant": "^0.4.0",
                 "tslib": "^1.9.3",
-                "zen-observable-ts": "^0.8.20"
+                "zen-observable-ts": "^0.8.21"
             }
         },
         "apollo-link-http-common": {
@@ -15850,9 +15850,9 @@
             "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
         },
         "zen-observable-ts": {
-            "version": "0.8.20",
-            "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
-            "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
+            "version": "0.8.21",
+            "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+            "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
             "requires": {
                 "tslib": "^1.9.3",
                 "zen-observable": "^0.8.0"


### PR DESCRIPTION
Update the transitive `apollo-link` dependency.

This should unblock #92, by including the fix to `apollo-link` that permits it to work with `graphql`@15